### PR TITLE
feat: ✨Added on dismiss callback in showcase view widget (#500)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [4.0.0] (unreleased)
 - [BREAKING] Fixed [#457](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/457) titleAlignment property does not work
 - Fix [#489](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/pull/489) - Fixed mounter issue inside the `_scrollIntoView` function
+- Feature [#500](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/500) - Added `onDismiss` callback in `ShowCaseWidget` which will trigger whenever `onDismiss` method is called
 
 ## [3.0.0] (Un-Released)
 - Updated minimum support to dart sdk 2.18.0

--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ WidgetsBinding.instance.addPostFrameCallback((_) =>
 | disableMovingAnimation              | bool                                          | false                        | Disable bouncing/moving transition for all showcases                                             |
 | onStart                             | Function(int?, GlobalKey)?                    |                              | Triggered on start of each showcase.                                                                |
 | onComplete                          | Function(int?, GlobalKey)?                    |                              | Triggered on completion of each showcase.                                                           |
-| onFinish                            | VoidCallback?                                 |                              | Triggered when all the showcases are completed                                                  |
+| onFinish                            | VoidCallback?                                 |                              | Triggered when all the showcases are completed
+| onDismiss                           | OnDismissCallback?                           |                              | Triggered when onDismiss is called                                                           |
 | enableShowcase                      | bool                                          | true                         | Enable or disable showcase globally.                                                                |
 | globalFloatingActionWidget          | FloatingActionWidget Function(BuildContext)?  |                              | Global Config for tooltip action to auto apply for all the toolTip .                               |
 | hideFloatingActionWidgetForShowcase | List<GlobalKey>                               | []                           | Hides globalFloatingActionWidget for the provided showcase widget keys.        |

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -64,6 +64,9 @@ class MyApp extends StatelessWidget {
           blurValue: 1,
           builder: (context) => const MailPage(),
           autoPlayDelay: const Duration(seconds: 3),
+          onDismiss: (key) {
+            debugPrint('Dismissed at $key');
+          },
         ),
       ),
     );

--- a/lib/src/showcase_widget.dart
+++ b/lib/src/showcase_widget.dart
@@ -25,7 +25,12 @@ import 'package:flutter/material.dart';
 import '../showcaseview.dart';
 
 typedef FloatingActionBuilderCallback = Widget Function(
-  BuildContext,
+  BuildContext context,
+);
+
+typedef OnDismissCallback = void Function(
+  /// this is the key on which showcase is dismissed
+  GlobalKey? dismissedAt,
 );
 
 class ShowCaseWidget extends StatefulWidget {
@@ -33,6 +38,9 @@ class ShowCaseWidget extends StatefulWidget {
 
   /// Triggered when all the showcases are completed.
   final VoidCallback? onFinish;
+
+  /// Triggered when onDismiss is called
+  final OnDismissCallback? onDismiss;
 
   /// Triggered every time on start of each showcase.
   final Function(int?, GlobalKey)? onStart;


### PR DESCRIPTION
# Description
Added `onDismiss` callback in `ShowCaseWidget` which will trigger whenever `onDismiss` method is
called


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [ ] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [ ] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ShowCaseView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
Closes [#500](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/500)

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
