### PR TITLE
fix: 🐛 Fixed cursor not changing to click mode issue (#503)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - [BREAKING] Fixed [#457](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/457) titleAlignment property does not work
 - Fix [#489](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/pull/489) - Fixed mounter issue inside the `_scrollIntoView` function
 - Feature [#500](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/500) - Added `onDismiss` callback in `ShowCaseWidget` which will trigger whenever `onDismiss` method is called
+- Fixed [#503](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/503) - Cursor not changing to click mode when it is hovering over the clickable widgets provided by this package.
 
 ## [3.0.0] (Un-Released)
 - Updated minimum support to dart sdk 2.18.0

--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -667,7 +667,10 @@ class _ShowcaseState extends State<Showcase> with WidgetsBindingObserver {
             arrowVerticalMargin: widget.arrowVerticalMargin,
             contentHeight: widget.height,
             contentWidth: widget.width,
-            onTooltipTap: _getOnTooltipTap,
+            onTooltipTap: 
+                widget.disposeOnTap == true || widget.onTooltipClick != null
+                    ? _getOnTooltipTap
+                    : null,
             tooltipPadding: widget.tooltipPadding,
             disableMovingAnimation: widget.disableMovingAnimation ?? showCaseWidgetState.disableMovingAnimation,
             disableScaleAnimation: widget.disableScaleAnimation ?? showCaseWidgetState.disableScaleAnimation,
@@ -722,7 +725,10 @@ class _TargetWidget extends StatelessWidget {
           ? AbsorbPointer(
               child: targetWidgetContent(),
             )
-          : targetWidgetContent(),
+          : MouseRegion(
+              cursor: SystemMouseCursors.click,
+              child: targetWidgetContent(),
+            ),
     );
   }
 

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -604,46 +604,51 @@ class __DefaultTooltipWidgetState extends State<_DefaultTooltipWidget>
           ),
           child: ClipRRect(
             borderRadius: widget.tooltipBorderRadius ?? BorderRadius.circular(8.0),
-            child: GestureDetector(
-              onTap: widget.onTooltipTap,
-              child: Container(
-                width: tooltipWidth,
-                padding: widget.tooltipPadding,
-                color: widget.tooltipBackgroundColor,
-                child: Column(
-                  children: <Widget>[
-                    if (widget.title != null)
+            child: MouseRegion(
+              cursor: widget.onTooltipTap == null
+                  ? MouseCursor.defer
+                  : SystemMouseCursors.click,
+              child: GestureDetector(
+                onTap: widget.onTooltipTap,
+                child: Container(
+                  width: tooltipWidth,
+                  padding: widget.tooltipPadding,
+                  color: widget.tooltipBackgroundColor,
+                  child: Column(
+                    children: <Widget>[
+                      if (widget.title != null)
+                        Align(
+                          alignment: widget.titleAlignment,
+                          child: Padding(
+                            padding: widget.titlePadding ?? EdgeInsets.zero,
+                            child: Text(
+                              widget.title!,
+                              textAlign: widget.titleTextAlign,
+                              textDirection: widget.titleTextDirection,
+                              style: widget.titleTextStyle ??
+                                  _textTheme.titleLarge!.copyWith(
+                                    color: widget.textColor,
+                                  ),
+                            ),
+                          ),
+                        ),
                       Align(
-                        alignment: widget.titleAlignment,
+                        alignment: widget.descriptionAlignment,
                         child: Padding(
-                          padding: widget.titlePadding ?? EdgeInsets.zero,
+                          padding: widget.descriptionPadding,
                           child: Text(
-                            widget.title!,
-                            textAlign: widget.titleTextAlign,
-                            textDirection: widget.titleTextDirection,
-                            style: widget.titleTextStyle ??
-                                _textTheme.titleLarge!.copyWith(
+                            widget.description,
+                            textAlign: widget.descriptionTextAlign,
+                            textDirection: widget.descriptionTextDirection,
+                            style: widget.descTextStyle ??
+                                _textTheme.titleSmall!.copyWith(
                                   color: widget.textColor,
                                 ),
                           ),
                         ),
                       ),
-                    Align(
-                      alignment: widget.descriptionAlignment,
-                      child: Padding(
-                        padding: widget.descriptionPadding,
-                        child: Text(
-                          widget.description,
-                          textAlign: widget.descriptionTextAlign,
-                          textDirection: widget.descriptionTextDirection,
-                          style: widget.descTextStyle ??
-                              _textTheme.titleSmall!.copyWith(
-                                color: widget.textColor,
-                              ),
-                        ),
-                      ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -848,18 +853,23 @@ class _CustomTooltipBaseWidgetState extends State<_CustomTooltipWidget>
           ).animate(_movingAnimation),
           child: Material(
             color: Colors.transparent,
-            child: GestureDetector(
-              onTap: widget.onTooltipTap,
-              child: Container(
-                padding: EdgeInsets.only(
-                  top: isArrowUp ? paddingTop : 0,
-                  bottom: isArrowUp ? 0 : paddingBottom,
-                ),
-                color: Colors.transparent,
-                child: Center(
-                  child: MeasureSize(
-                    onSizeChange: onSizeChange,
-                    child: child,
+            child: MouseRegion(
+              cursor: widget.onTooltipTap == null
+                  ? MouseCursor.defer
+                  : SystemMouseCursors.click,
+              child: GestureDetector(
+                onTap: widget.onTooltipTap,
+                child: Container(
+                  padding: EdgeInsets.only(
+                    top: isArrowUp ? paddingTop : 0,
+                    bottom: isArrowUp ? 0 : paddingBottom,
+                  ),
+                  color: Colors.transparent,
+                  child: Center(
+                    child: MeasureSize(
+                      onSizeChange: onSizeChange,
+                      child: child,
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
# Description

fix: 🐛 Fixed curser not changing to click mode issue

- When cursor is hovering over the default action widget it does not change to click mode


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [ ] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [ ] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ShowCaseView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.


## Related Issues
Closes [#503](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/503)

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
